### PR TITLE
Fix : item - 상품 검색시 사용하는 요청/ 응답 Dto에 ItemStatus 필드 추가

### DIFF
--- a/src/main/java/com/moodeng/ezshop/dto/request/ItemSearchRequestDto.java
+++ b/src/main/java/com/moodeng/ezshop/dto/request/ItemSearchRequestDto.java
@@ -30,8 +30,7 @@ public class ItemSearchRequestDto {
     private Integer sortedType = 1; //정렬 기준(1 : 신상품순, 2 : 높은 가격순, 3 : 낮은 가격순) (Default: 1)
     
     // seller가 자기상품을 조회하는 경우가 추가되면서 일반유저와 판매자가 볼 수 있는 아이템상태가 다르므로 ItemStatus필드를 추가함
-    // 여러개를 선택할 수 있으므로 list로 받음
-    private List<ItemStatus> itemStatus;
+    private ItemStatus itemStatus;
 
 
     public Pageable toPageable(){

--- a/src/main/java/com/moodeng/ezshop/dto/request/ItemSearchRequestDto.java
+++ b/src/main/java/com/moodeng/ezshop/dto/request/ItemSearchRequestDto.java
@@ -12,8 +12,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.util.StringUtils;
 
-import java.util.List;
-
 @Getter
 @Setter
 public class ItemSearchRequestDto {

--- a/src/main/java/com/moodeng/ezshop/dto/response/ItemDetailResponseDto.java
+++ b/src/main/java/com/moodeng/ezshop/dto/response/ItemDetailResponseDto.java
@@ -1,6 +1,7 @@
 package com.moodeng.ezshop.dto.response;
 
 import com.moodeng.ezshop.constant.DeliveryType;
+import com.moodeng.ezshop.constant.ItemStatus;
 import com.moodeng.ezshop.entity.Item;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,7 @@ public class ItemDetailResponseDto {
     private String name;
     private Integer price;
     private Integer stockQuantity;
+    private ItemStatus itemStatus;
     private String thumbnailUrl;
     private String detailImageUrl;
     private String origin;
@@ -27,6 +29,7 @@ public class ItemDetailResponseDto {
                 .name(item.getName())
                 .price(item.getPrice())
                 .stockQuantity(item.getStockQuantity())
+                .itemStatus(item.getStatus())
                 .thumbnailUrl(item.getThumbnailUrl())
                 .detailImageUrl(item.getDetailImageUrl())
                 .origin(item.getOrigin())

--- a/src/main/java/com/moodeng/ezshop/dto/response/ItemSimpleResponseDto.java
+++ b/src/main/java/com/moodeng/ezshop/dto/response/ItemSimpleResponseDto.java
@@ -1,6 +1,7 @@
 package com.moodeng.ezshop.dto.response;
 
 
+import com.moodeng.ezshop.constant.ItemStatus;
 import com.moodeng.ezshop.entity.Item;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,6 +16,7 @@ public class ItemSimpleResponseDto {
     private String name;
     private Integer price;
     private String thumbnailUrl; // Full URL
+    private ItemStatus itemStatus;
 
     public static ItemSimpleResponseDto fromEntity(Item item) {
         return ItemSimpleResponseDto.builder()
@@ -22,6 +24,7 @@ public class ItemSimpleResponseDto {
                 .name(item.getName())
                 .price(item.getPrice())
                 .thumbnailUrl(item.getThumbnailUrl())
+                .itemStatus(item.getStatus())
                 .build();
     }
 }

--- a/src/main/java/com/moodeng/ezshop/repository/ItemRepository.java
+++ b/src/main/java/com/moodeng/ezshop/repository/ItemRepository.java
@@ -18,7 +18,7 @@ public interface ItemRepository extends JpaRepository<Item,Long> {
     // pagination으로 인해 자동으로 정렬까지 됨
     @Query("""
             select i from Item i left join i.category c
-            where (:statusList is null or i.status in :statusList)
+            where (:status is null or i.status = :status)
             and (:keyword is null or i.name like %:keyword%)
             and (:categoryName is null or c.name = :categoryName)
             and (:minPrice is null or i.price >= :minPrice)
@@ -26,7 +26,7 @@ public interface ItemRepository extends JpaRepository<Item,Long> {
             and (:sellerEmail is null or i.user.email = :sellerEmail)
     """)
     Page<Item> findBySearchConditions(
-            @Param("statusList") List<ItemStatus> status,
+            @Param("status") ItemStatus status,
             @Param("keyword") String keyword,
             @Param("categoryName") String categoryName,
             @Param("minPrice") Integer minPrice,

--- a/src/main/java/com/moodeng/ezshop/service/ItemService.java
+++ b/src/main/java/com/moodeng/ezshop/service/ItemService.java
@@ -66,7 +66,7 @@ public class ItemService {
 
         // 일반 구매자가 검색하는 경우이므로 ItemStatus는 ACTIVE로 , sellerEmail은 null로 고정
         Page<Item> itemPage = itemRepository.findBySearchConditions(
-                List.of(ItemStatus.ACTIVE),
+                ItemStatus.ACTIVE,
                 requestDto.getKeyword(),
                 requestDto.getCategoryName(),
                 minPrice,
@@ -87,9 +87,7 @@ public class ItemService {
         Integer maxPrice = requestDto.getMaxPrice();
 
         // statusList가 null 인경우 jpql의 is null이 동작되어 전체 조회가 가능하도록 하기 위한 전처리
-        List<ItemStatus> statusList = (requestDto.getItemStatus() == null || requestDto.getItemStatus().isEmpty())
-                                            ? null
-                                            : requestDto.getItemStatus();
+        ItemStatus status = requestDto.getItemStatus();
 
         // 판매자가 자신의 상품을 검색하는 경우에 ItemStatus를 동적으로 처리
         Page<Item> itemPage = itemRepository.findBySearchConditions(

--- a/src/main/java/com/moodeng/ezshop/service/ItemService.java
+++ b/src/main/java/com/moodeng/ezshop/service/ItemService.java
@@ -93,7 +93,7 @@ public class ItemService {
 
         // 판매자가 자신의 상품을 검색하는 경우에 ItemStatus를 동적으로 처리
         Page<Item> itemPage = itemRepository.findBySearchConditions(
-                statusList,
+                status,
                 requestDto.getKeyword(),
                 requestDto.getCategoryName(),
                 minPrice,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->

- ItemDetailResponseDto에서 itemstatus도 같이 가져오게 수정
- ItemSearchRequestDto에서 item status를 list가 아닌 단일 값으로 받아오게 수정

## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
