### PR TITLE
Feat : Cart - 장바구니 조회 시 응답 dto에 카트id와 배송 타입 추가

### DIFF
--- a/src/main/java/com/moodeng/ezshop/dto/response/CartItemResponseDto.java
+++ b/src/main/java/com/moodeng/ezshop/dto/response/CartItemResponseDto.java
@@ -1,5 +1,6 @@
 package com.moodeng.ezshop.dto.response;
 
+import com.moodeng.ezshop.constant.DeliveryType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 public class CartItemResponseDto {
     private Long cartItemId; // cartItemId 추가함
     private Long itemId;
+    private DeliveryType deliveryType; // deliveryType 추가
     private String name;
     private String thumbnailUrl;
     private int price;

--- a/src/main/java/com/moodeng/ezshop/dto/response/CartResponseDto.java
+++ b/src/main/java/com/moodeng/ezshop/dto/response/CartResponseDto.java
@@ -9,6 +9,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class CartResponseDto {
+    private Long cartId;
     private int totalCount;
     private int totalPrice;
     private List<CartItemResponseDto> items;

--- a/src/main/java/com/moodeng/ezshop/service/CartService.java
+++ b/src/main/java/com/moodeng/ezshop/service/CartService.java
@@ -40,6 +40,7 @@ public class CartService {
                 .map(cartItem -> CartItemResponseDto.builder()
                         .cartItemId(cartItem.getId()) // cartItemId 추가함
                         .itemId(cartItem.getItem().getId())
+                        .deliveryType(cartItem.getItem().getDeliveryType()) // deliveryType 추가
                         .name(cartItem.getItem().getName())
                         .thumbnailUrl(cartItem.getItem().getThumbnailUrl())
                         .price(cartItem.getItem().getPrice())
@@ -57,6 +58,7 @@ public class CartService {
                 .sum();
 
         return CartResponseDto.builder()
+                .cartId(cart.getId())
                 .totalCount(totalCount)
                 .totalPrice(totalPrice)
                 .items(itemDtos)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #46 

## ✅ 작업 내용
- 장바구니 조회 응답 dto에 카트id와 배송 타입을 추가

## 📸 스크린샷 

## 🗨️ 참고 사항
